### PR TITLE
Add files via upload

### DIFF
--- a/TelegramForwarder.py
+++ b/TelegramForwarder.py
@@ -1,3 +1,4 @@
+
 import time
 import asyncio
 from telethon.sync import TelegramClient
@@ -19,12 +20,12 @@ class TelegramForwarder:
 
         # Get a list of all the dialogs (chats)
         dialogs = await self.client.get_dialogs()
-        chats_file = open(f"chats_of_{self.phone_number}.txt", "w")
+        chats_file = open(f"chats_of_{self.phone_number}.txt", "w", encoding="utf-8")  # Specify encoding
         # Print information about each chat
         for dialog in dialogs:
             print(f"Chat ID: {dialog.id}, Title: {dialog.title}")
             chats_file.write(f"Chat ID: {dialog.id}, Title: {dialog.title} \n")
-          
+
 
         print("List of groups printed successfully!")
 


### PR DESCRIPTION
Description:

When running the list_chats method in the TelegramForwarder class, there's an issue with encoding Unicode characters when writing chat details to a file. This results in a UnicodeEncodeError with the message 'charmap' codec can't encode character. This typically happens when non-ASCII characters are encountered, such as emojis or non-Latin characters.

Proposed Solution:
To fix this issue, we can explicitly specify the UTF-8 encoding when opening the file for writing chat details. This encoding supports Unicode characters universally and should prevent encoding errors.